### PR TITLE
Improve button realism

### DIFF
--- a/src/lib/components/banner/parts/Footer.svelte
+++ b/src/lib/components/banner/parts/Footer.svelte
@@ -177,7 +177,7 @@
 			background: #ede9cc;
 		}
 		100% {
-			border: 3px solid darkgray;
+			border: 0.2rem solid darkgray;
 			color: white;
 			background: linear-gradient(rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05)),
 			#e0ddd4;

--- a/src/lib/components/banner/parts/Footer.svelte
+++ b/src/lib/components/banner/parts/Footer.svelte
@@ -66,7 +66,7 @@
 		</div>
 		<div class="right roll-button">
 			{#if bannerActiveType !== 'beginner'}
-				<button class="single" on:click={handleSingleRollClick}>
+				<button class="single wish-button" on:click={handleSingleRollClick}>
 					<div class="top">Wish x1</div>
 					<div class="bottom">
 						<Icon type={fateType} />
@@ -78,7 +78,7 @@
 				</button>
 			{/if}
 
-			<button class="ten" on:click={handleMultiRollClick}>
+			<button class="ten wish-button" on:click={handleMultiRollClick}>
 				{#if bannerActiveType === 'beginner'}
 					<span class="discount">-20%</span>
 				{/if}
@@ -126,11 +126,15 @@
 		text-shadow: 0 0 3px rgba(0, 0, 0, 0.5);
 	}
 
-	button {
+	.wish-button {
 		transform: scale(1);
 		transition: all 0.2s;
 		color: #4a5265;
 		text-decoration: none;
+	}
+
+	.wish-button:active {
+  		filter: brightness(85%);
 	}
 	button:active {
 		transform: scale(0.95);

--- a/src/lib/components/banner/parts/Footer.svelte
+++ b/src/lib/components/banner/parts/Footer.svelte
@@ -147,17 +147,38 @@
 
 	.menu-button button {
 		border-radius: 50px;
-		background-color: #fff;
-		border: 3px solid #fff;
+		background-color: #e0ddd4;
+		box-shadow: 0 2px 2px 0 rgba(100, 100, 100, 0.2),
+    0 2px 2px 0 rgba(100, 100, 100, 0.19);
 		padding: 3px 20px;
 		margin: 2px 5px;
 		transition: all 0.2s;
+		border: solid transparent;
 	}
 
-	.menu-button button:active,
 	.menu-button button:hover {
-		background-color: var(--tertiary-color);
+		border: 3px solid white;
+		transition: none;
 	}
+
+	.menu-button button:active {
+		animation-name: colourchange;
+		animation-duration: 0.2s;
+		animation-fill-mode: forwards;
+	}
+
+	@keyframes colourchange {
+		50% {
+			color: #ffffda;
+			background: #ede9cc;
+		}
+		100% {
+			border: 3px solid darkgray;
+			color: white;
+			background: linear-gradient(rgba(0, 0, 0, 0.05), rgba(0, 0, 0, 0.05)),
+			#e0ddd4;
+		}
+		}
 
 	.roll-button {
 		text-align: right;

--- a/src/lib/components/banner/parts/Footer.svelte
+++ b/src/lib/components/banner/parts/Footer.svelte
@@ -67,13 +67,12 @@
 		<div class="right roll-button">
 			{#if bannerActiveType !== 'beginner'}
 				<button class="single wish-button" on:click={handleSingleRollClick}>
-					<div class="top">Wish x1</div>
+					<div class="top">Wish ×1</div>
 					<div class="bottom">
 						<Icon type={fateType} />
-						<span style="margin-left: 7px">
-							x
-							<span class:red={fateQty < 1 && !$unlimitedFates}> 1 </span></span
-						>
+						<span style="margin-left: 7px" class:red={fateQty < 1 && !$unlimitedFates}>
+							x 1
+						</span>
 					</div>
 				</button>
 			{/if}
@@ -82,13 +81,12 @@
 				{#if bannerActiveType === 'beginner'}
 					<span class="discount">-20%</span>
 				{/if}
-				<div class="top">Wish x10</div>
+				<div class="top">Wish ×10</div>
 				<div class="bottom">
 					<Icon type={fateType} />
-					<span style="margin-left: 7px">
-						x
-						<span class:red={fateQty < multiRollPrice && !$unlimitedFates}> {multiRollPrice} </span>
-					</span>
+						<span style="margin-left: 7px" class:red={fateQty < 1 && !$unlimitedFates}>
+							x {multiRollPrice}
+						</span>
 				</div>
 			</button>
 		</div>

--- a/src/lib/components/menu/MainMenu.svelte
+++ b/src/lib/components/menu/MainMenu.svelte
@@ -23,7 +23,7 @@
 	// Components
 	import PopUp from '$lib/components/utility/PopUp.svelte';
 	import Toast from '$lib/components/utility/Toast.svelte';
-	import Option from './Option.svelte';
+	import Option from './option.svelte';
 	import { browser } from '$app/env';
 
 	export let show = false;


### PR DESCRIPTION
 - Fix a case-insensitive import failing on systems that are case sensitive
 - Add animations to shop / details / history buttons & restyle to match the base game:
![image](https://user-images.githubusercontent.com/25178974/179602483-6021693a-069e-47de-bb9c-7168366ababd.png)

Wish buttons:
- Adjust button shading on click to match base game
- Adjust text colouring and use multiplication sign to match base game:
![image](https://user-images.githubusercontent.com/25178974/179602431-c8f889d9-f1a9-46d2-8e64-ade1aebcffcd.png)

